### PR TITLE
fix: wrap CallTool results in MCP content format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1202,7 +1202,7 @@ server.setRequestHandler(CallToolRequestSchema, async request => {
     }
     
     log(`Tool ${name} executed successfully`, 'debug');
-    return result;
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
   } catch (error) {
     log(`Tool ${name} failed: ${error}`, 'error');
     throw new Error(`Tool execution failed: ${error}`);


### PR DESCRIPTION
## Summary

- The `CallToolRequestSchema` handler returns raw result objects (e.g. `{files: [], nextPageToken, totalResults}`) instead of the MCP-required `{content: [{type: "text", text: "..."}]}` format
- MCP clients (Claude Code, Cursor, VS Code) receive empty responses for **all** tool calls — the API calls succeed but data is silently dropped because the client expects a `content` array
- One-line fix: wrap the return value in `{ content: [{ type: "text", text: JSON.stringify(result, null, 2) }] }`

## How to reproduce

1. Configure `mcp-google-drive` with valid OAuth2 credentials
2. Call any tool (e.g. `list_files`, `search_files`)
3. Result: empty response / "completed with no output"
4. Direct Google Drive API calls with the same token return data correctly

## Test plan

- [x] Verified fix returns 3+ files from `list_files` via MCP stdio test
- [x] Verified fix works in Claude Code MCP client (live tool call)
- [x] TypeScript type-check passes (`tsc --noEmit`)